### PR TITLE
feat/cast ray on blocks

### DIFF
--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -32,7 +32,7 @@ const (
 type Block struct {
 	Position rl.Vector3
 	Size     rl.Vector3
-	Rotn     float32
+	Rotation float32
 	Health   float32 // [0..1]
 	IsActive bool
 	State    BlockState
@@ -59,7 +59,7 @@ func NewBlock(pos, size rl.Vector3) Block {
 	return Block{
 		Position: pos,
 		Size:     size,
-		Rotn:     0.0,
+		Rotation: 0.0,
 		State:    DirtBlockState,
 		IsActive: true,
 	}
@@ -75,31 +75,23 @@ func (o *Block) NextState() {
 
 func InitBlocks(dst *[]Block, positions []rl.Vector3) {
 	var mu sync.Mutex
+
 	mu.Lock()
+	defer mu.Unlock()
 
 	for i := range positions {
 		size := rl.Vector3Multiply(
 			rl.NewVector3(1, 1, 1),
 			rl.NewVector3(
-				float32(rl.GetRandomValue(88, 101))/100.,
-				float32(cmp.Or(
-					blockModelYSize,
-					cmp.Or(
-						rl.GetRandomValue(100, 100), // Consistent size--lower than player
-						rl.GetRandomValue(200, 200), // Consistent size--higher than player
-						rl.GetRandomValue(100, 300), // Non-Consistent size
-					)/100.),
-				),
-				float32(rl.GetRandomValue(88, 101))/100.))
-
-		fmt.Printf("positions[i]: %v\n", positions[i])
-		size = common.Vector3One
+				float32(rl.GetRandomValue(88, 94))/100.,
+				float32(rl.GetRandomValue(100, 100))/100.,
+				float32(rl.GetRandomValue(88, 94))/100.,
+			),
+		)
 		obj := NewBlock(positions[i], size)
-		obj.Rotn = cmp.Or(float32(rl.GetRandomValue(-50, 50)/10.), 0.)
-
+		obj.Rotation = cmp.Or(float32(rl.GetRandomValue(-40, 40)/10.), 0.)
 		*dst = append(*dst, obj)
 	}
-	mu.Unlock()
 }
 
 func SetupBlockModels() {
@@ -127,7 +119,7 @@ func SetupBlockModels() {
 
 func (b Block) Draw() {
 	if b.IsActive {
-		rl.DrawModelEx(blockModels[b.State], b.Position, common.YAxis, b.Rotn, b.Size, rl.White)
+		rl.DrawModelEx(blockModels[b.State], b.Position, common.YAxis, b.Rotation, b.Size, rl.White)
 	}
 }
 

--- a/internal/block/block.go
+++ b/internal/block/block.go
@@ -69,7 +69,11 @@ func InitBlocks(dst *[]Block, positions []rl.Vector3) {
 			rl.NewVector3(1, 1, 1),
 			rl.NewVector3(
 				float32(rl.GetRandomValue(88, 101))/100.,
-				float32(rl.GetRandomValue(100, 300))/100.,
+				float32(cmp.Or(
+					rl.GetRandomValue(200, 200), // Consistent size--higher than player
+					rl.GetRandomValue(100, 100), // Consistent size--lower than player
+					rl.GetRandomValue(100, 300), // Non-Consistent size
+				)/100.),
 				float32(rl.GetRandomValue(88, 101))/100.))
 
 		obj := NewBlock(positions[i], size)
@@ -104,7 +108,7 @@ func SetupBlockModels() {
 }
 
 func (b Block) Draw() {
-	if /* b.State > 0 && */ b.IsActive {
+	if b.IsActive {
 		rl.DrawModelEx(blockModels[b.State], b.Pos, common.YAxis, b.Rotn, b.Size, rl.White)
 	}
 }

--- a/internal/common/raylibutil.go
+++ b/internal/common/raylibutil.go
@@ -9,3 +9,9 @@ func GetBoundingBoxFromPositionSizeV(pos, size rl.Vector3) rl.BoundingBox {
 		rl.NewVector3(pos.X-size.X/2, pos.Y-size.Y/2, pos.Z-size.Z/2),
 		rl.NewVector3(pos.X+size.X/2, pos.Y+size.Y/2, pos.Z+size.Z/2))
 }
+
+func GetCollisionPointBox(point rl.Vector3, box rl.BoundingBox) bool {
+	return point.X >= box.Min.X && point.X <= box.Max.X &&
+		point.Y >= box.Min.Y && point.Y <= box.Max.Y &&
+		point.Z >= box.Min.Z && point.Z <= box.Max.Z
+}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -4,6 +4,7 @@ package game
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -197,13 +198,26 @@ func Run() {
 	currentScreen = logoGameScreen
 	logo.Init()
 
+	if true {
+		slog.Warn("rl.SetMasterVolume(.2)")
+		rl.SetMasterVolume(.2)
+	}
+
 	if _, ok := os.LookupEnv("PLATFORM_WEB"); ok {
 		// emscripten_set_main_loop(UpdateDrawFrame, 60, 1)
 		log.Printf("env: %v\n", "PLATFORM_WEB")
 	} else {
 		rl.SetTargetFPS(60)
 
+		//
+		//
+		//
+		//
 		// Main game loop
+		//
+		//
+		//
+		//
 		for !rl.WindowShouldClose() {
 			UpdateDrawFrame()
 		}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -62,7 +62,8 @@ func NewPlayer(camera rl.Camera3D) Player {
 				levelPrimes = append(levelPrimes, primes[i+1])
 			}
 			// WARN: This panicked as levelIDS are 1 index based, to avoid level 0
-			x := 2 * levelPrimes[int(common.SavedgameSlotData.CurrentLevelID)-1]
+			x := 5 * levelPrimes[int(common.SavedgameSlotData.CurrentLevelID)-1]
+			x = int32(mathutil.RoundEvenF(x))
 			player.MaxCargoCapacity = x
 		}
 	}
@@ -425,6 +426,11 @@ func ToggleEquippedModels(values [MaxBoneSockets]bool) {
 
 // FIXME: Camera gets stuck if player keeps moving into the box.
 // NOTE:  Maybe lerp or free camera if "distance to the box is less" or touching.
+// PERF: https://github.com/raylib-extras/examples-c/blob/6ed2ac244d961239b1695d0b6a729f6fd7bc209b/platformer_motion/platformer.c#L34C1-L147C2
+//
+//	checks a moving rectangle against some static object, stopping them motion based on what side of the static object is hit.
+//	hit booleans return back what part of the object was hit to help with state collisons
+//	void CollideRectWithObject(const Rectangle mover, const Rectangle object, Vector2* motion, bool* hitSide, bool* hitTop, bool* hitBottom)
 func RevertPlayerAndCameraPositions(
 	dstPlayer *Player,
 	srcPlayer Player,

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -20,7 +20,7 @@ import (
 type Player struct {
 	Position    rl.Vector3
 	Size        rl.Vector3
-	Rotation    int32
+	Rotation    int32 // FIXME: We are adding 90 degree to adapt to original model's default rotation
 	BoundingBox rl.BoundingBox
 
 	Collisions            rl.Quaternion

--- a/internal/projectile/projectile.go
+++ b/internal/projectile/projectile.go
@@ -1,0 +1,60 @@
+package projectile
+
+import (
+	"example/depths/internal/util/mathutil"
+
+	rl "github.com/gen2brain/raylib-go/raylib"
+)
+
+const (
+	MaxProjectiles                  = int32(64)
+	MaxTimeLeft                     = float32(.8)  // Should decrement time to compare with by dt (i.e. rl.GetFrameTime())
+	MaxProjectileFireRateTimerLimit = float32(0.1) //  Reduce this to increase fire rate.
+)
+
+type ProjectileSOA struct { // size=1352 (0x548)
+	Position           [MaxProjectiles]rl.Vector3
+	AngleXZPlaneDegree [MaxProjectiles]float32 // Direction [MaxProjectiles]rl.Vector3
+	TimeLeft           [MaxProjectiles]float32
+	IsActive           [MaxProjectiles]bool
+
+	CircularBufIndex int32
+	FireRateTimer    float32
+}
+
+// See https://github.com/lloydlobo/tinycreatures/blob/210c4a44ed62fbb08b5f003872e046c99e288bb9/src/main.lua#L2522C3-L2529C61
+func (ps *ProjectileSOA) Reset() {
+	for i := range MaxProjectiles {
+		ps.Position[i] = rl.Vector3{}
+		ps.AngleXZPlaneDegree[i] = 0
+		ps.TimeLeft[i] = 0.
+		ps.IsActive[i] = false
+	}
+	ps.CircularBufIndex = 0
+	ps.FireRateTimer = 0
+}
+
+// See https://github.com/lloydlobo/tinycreatures/blob/210c4a44ed62fbb08b5f003872e046c99e288bb9/src/main.lua#L341C1-L356C4
+func (ps *ProjectileSOA) Emit(position rl.Vector3, rotationDegree float32) {
+	ps.Position[ps.CircularBufIndex] = position
+	ps.Position[ps.CircularBufIndex] = position
+	ps.TimeLeft[ps.CircularBufIndex] = MaxTimeLeft
+	ps.IsActive[ps.CircularBufIndex] = true
+	ps.AngleXZPlaneDegree[ps.CircularBufIndex] = rotationDegree
+
+	// Increment index: (ring like data structure / circular reusable buffer)
+	ps.CircularBufIndex = (ps.CircularBufIndex + 1) % MaxProjectiles
+
+	// Reset to default timer: (assume cooldown)
+	ps.FireRateTimer = MaxProjectileFireRateTimerLimit
+}
+
+// Example
+func FireEntityProjectile(ps *ProjectileSOA, entityPos, entitySize rl.Vector3, rotationDegree float32) {
+	initialOrigin := rl.Vector3{
+		X: entityPos.X + mathutil.CosF(rotationDegree*rl.Deg2rad)*entitySize.X/2,
+		Y: entityPos.Y + entitySize.Y/2,
+		Z: entityPos.Z + mathutil.SinF(rotationDegree*rl.Deg2rad)*entitySize.Z/2,
+	}
+	ps.Emit(initialOrigin, rotationDegree)
+}

--- a/internal/projectile/projectile.go
+++ b/internal/projectile/projectile.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	MaxProjectiles                  = int32(64)
-	MaxTimeLeft                     = float32(.8)  // Should decrement time to compare with by dt (i.e. rl.GetFrameTime())
+	MaxProjectiles = int32(64)
+	MaxTimeLeft    = float32(1.0) // 1 second in 60fps. Should decrement time to compare with by dt (i.e. rl.GetFrameTime())
+	// WARN: UNIMPLEMENTED
 	MaxProjectileFireRateTimerLimit = float32(0.1) //  Reduce this to increase fire rate.
 )
 

--- a/internal/screen/drillroom/drillroom.go
+++ b/internal/screen/drillroom/drillroom.go
@@ -189,9 +189,6 @@ func Init() {
 		isTriggerActive[TriggerStartDrill] = true // Only enable drill
 	}
 
-	// Unequip hat sword shield
-	player.ToggleEquippedModels([player.MaxBoneSockets]bool{false, false, false})
-
 	// Compute once
 	drillroomExitBoundingBox = common.GetBoundingBoxFromPositionSizeV(
 		xFloor.Position,

--- a/internal/screen/gameplay/gameplay.go
+++ b/internal/screen/gameplay/gameplay.go
@@ -603,7 +603,7 @@ func Draw() {
 	}
 
 	// Draw ray reticle on block
-	if closestBlockIndex := GetClosestBlockIndexOnRayCollision(); closestBlockIndex > -1 && closestBlockIndex < len(xBlocks) {
+	if closestBlockIndex := GetClosestMiningBlockIndexOnRayCollision(); closestBlockIndex > -1 && closestBlockIndex < len(xBlocks) {
 		collision := rl.GetRayCollisionBox(gPlayerRay, xBlocks[closestBlockIndex].GetBlockBoundingBox())
 		pos := rl.GetWorldToScreen(collision.Point, camera) // Draw a diamond
 		rl.DrawRectanglePro(rl.NewRectangle(pos.X, pos.Y, 5, 5), rl.NewVector2(0, 0), 45, rl.Fade(rl.Orange, .3))
@@ -705,14 +705,16 @@ func DrawProjectiles() {
 		if !projectiles.IsActive[i] {
 			continue
 		}
-		rl.DrawSphere(projectiles.Position[i], .05, rl.Orange)              // Projectile Head
-		rl.DrawSphereWires(projectiles.Position[i], .05, 16, 16, rl.Orange) // Projectile Head
 
-		const maxTrailThick = 0.05 // Radius
-		const maxTrailLength = 3   // Projectile trail
-		radius := float32(maxTrailThick * (projectiles.TimeLeft[i] / projectile.MaxTimeLeft))
+		const maxTrailLength = 3. // Projectile trail
+		const maxTrailThick = .04 // Radius
+
+		rl.DrawSphere(projectiles.Position[i], maxTrailThick+.005, rl.Fade(rl.Orange, .6)) // Projectile Head
+		rl.DrawSphereWires(projectiles.Position[i], maxTrailThick+.005, 16, 16, rl.Gold)   // Projectile Head
+
+		timeFactor := (projectiles.TimeLeft[i] / projectile.MaxTimeLeft)
+		radius := float32(maxTrailThick * timeFactor)
 		angle := projectiles.AngleXZPlaneDegree[i] * rl.Deg2rad
-
 		trailLength := float32(maxTrailLength)
 
 		// Avoid passing projectile trail through the player body itself when animation just started
@@ -726,8 +728,9 @@ func DrawProjectiles() {
 			Y: 0,
 			Z: projectiles.Position[i].Z - mathutil.SinF(angle)*trailLength,
 		}
-		rl.DrawLine3D(prevPos, currPos, rl.Fade(rl.Orange, .3))
-		rl.DrawCapsule(prevPos, currPos, radius, 16, 16, rl.Fade(rl.Orange, .3))
+
+		// rl.DrawCapsule(prevPos, currPos, radius, 16, 16, rl.Fade(rl.Orange, .35))
+		rl.DrawCylinderEx(prevPos, currPos, (radius/5)/timeFactor, radius, 16, rl.Fade(rl.Orange, .35))
 	}
 }
 

--- a/internal/screen/gameplay/gameplay.go
+++ b/internal/screen/gameplay/gameplay.go
@@ -82,13 +82,24 @@ func Init() {
 		panic("unexpected levelID")
 	}
 
+	// PERF: See also https://github.com/raylib-extras/extras-c/blob/main/cameras/rlTPCamera/rlTPCamera.h
+	// ViewCamera.target = position;
+	// ViewCamera.position = Vector3Add(ViewCamera.target, Vector3{ 0, 0, CameraPullbackDistance });
+	// ViewCamera.up = Vector3{ 0.0f, 1.0f, 0.0f };
+	// ViewCamera.fovy = fovY;
+	// ViewCamera.projection = CAMERA_PERSPECTIVE;
+	cameraPullbackDistance := float32(cmp.Or(3, 5))
+
 	camera = rl.Camera3D{
-		Position:   rl.NewVector3(0., 10., 10.),
-		Target:     rl.NewVector3(0., .5, 0.),
+		Target: rl.NewVector3(0., .5, 0.),
+		Position: cmp.Or(
+			rl.Vector3Add(rl.NewVector3(0., .5, 0.), rl.NewVector3(0, 0, cameraPullbackDistance)),
+			rl.NewVector3(0., 10., 10.),
+		),
 		Up:         rl.NewVector3(0., 1., 0.),
 		Fovy:       15. * float32(cmp.Or(4., 3., 2.)),
 		Projection: rl.CameraPerspective,
-	} // See also https://github.com/raylib-extras/extras-c/blob/main/cameras/rlTPCamera/rlTPCamera.h
+	}
 
 	loadNewEntityData := func() {
 		var mu sync.Mutex


### PR DESCRIPTION
## Changes

- feat: draw player ray cast collision point on 2d screen and ray on 3d world
- feat: add projectile prototype that player can fire
- fix: adjust bounding box for block based on model being drawn at the bottom of a unit cube
- fix: use better camera positioning with camera pull back from raylib-extras example
- style: make projectile trail pointy at end position
- feat: play sound on laser fire
